### PR TITLE
Fixed dimming

### DIFF
--- a/src/main/java/gregtech/api/gui/GuiTextures.java
+++ b/src/main/java/gregtech/api/gui/GuiTextures.java
@@ -38,6 +38,7 @@ public class GuiTextures {
     public static final TextureArea BUTTON_ALLOW_IMPORT_EXPORT = TextureArea.fullImage("textures/gui/widget/button_allow_import_export.png");
     public static final TextureArea BUTTON_CLEAR_GRID = TextureArea.fullImage("textures/gui/widget/button_clear_grid.png");
     public static final TextureArea LOCK = TextureArea.fullImage("textures/gui/widget/lock.png");
+
     //INDICATORS & ICONS
     public static final TextureArea INDICATOR_NO_ENERGY = TextureArea.fullImage("textures/gui/base/indicator_no_energy.png");
     public static final TextureArea TANK_ICON = TextureArea.fullImage("textures/gui/base/tank_icon.png");
@@ -125,5 +126,6 @@ public class GuiTextures {
     public static final TextureArea PROGRESS_BAR_SLICE = TextureArea.fullImage("textures/gui/progress_bar/progress_bar_slice.png");
     public static final TextureArea PROGRESS_BAR_WIREMILL = TextureArea.fullImage("textures/gui/progress_bar/progress_bar_wiremill.png");
 
-
+    //JEI
+    public static final TextureArea MULTIBLOCK_CATEGORY = TextureArea.fullImage("textures/gui/icon/coke_oven.png");
 }

--- a/src/main/java/gregtech/api/gui/GuiTextures.java
+++ b/src/main/java/gregtech/api/gui/GuiTextures.java
@@ -128,4 +128,6 @@ public class GuiTextures {
 
     //JEI
     public static final TextureArea MULTIBLOCK_CATEGORY = TextureArea.fullImage("textures/gui/icon/coke_oven.png");
+    public static final TextureArea INFO_ICON = TextureArea.fullImage("textures/gui/widget/information.png");
+
 }

--- a/src/main/java/gregtech/api/render/scene/WorldSceneRenderer.java
+++ b/src/main/java/gregtech/api/render/scene/WorldSceneRenderer.java
@@ -182,7 +182,6 @@ public class WorldSceneRenderer {
         //rewind buffer after read
         OBJECT_POS_BUFFER.rewind();
 
-        //System.out.println(String.format("%f %f %f %f", pixelDepth, posX, posY, posZ));
         //if we didn't hit anything, just return null
         //also return null if hit is too far from us
         if (posY < -100.0f) {
@@ -277,7 +276,6 @@ public class WorldSceneRenderer {
         //Re-enable disabled states
         GlStateManager.disableBlend();
         GlStateManager.disableDepth();
-        minecraft.entityRenderer.enableLightmap();
 
         //Reset Attributes
         GL11.glPopAttrib();

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoCategory.java
@@ -12,9 +12,7 @@ import mezz.jei.api.gui.IRecipeLayout;
 import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.IRecipeCategory;
 import mezz.jei.gui.recipes.RecipeLayout;
-import net.minecraft.client.Minecraft;
 import net.minecraft.client.resources.I18n;
-import net.minecraft.util.ResourceLocation;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -24,14 +22,11 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
     private final IDrawable background;
     private final IDrawable icon;
     private final IGuiHelper guiHelper;
-    private IDrawable slot;
 
     public MultiblockInfoCategory(IJeiHelpers helpers) {
         this.guiHelper = helpers.getGuiHelper();
         this.background = this.guiHelper.createBlankDrawable(176, 166);
-        ResourceLocation iconLocation = new ResourceLocation(GTValues.MODID, "textures/gui/icon/coke_oven.png");
-        this.icon = this.guiHelper.createDrawable(iconLocation, 0, 0, 16, 16, 16, 16);
-        this.slot = guiHelper.createDrawable(GuiTextures.SLOT.imageLocation, 0, 0, 18, 18, 18, 18);
+        this.icon = guiHelper.drawableBuilder(GuiTextures.MULTIBLOCK_CATEGORY.imageLocation, 0,0,18,18).setTextureSize(18,18).build();
     }
 
     public static final Map<String, MultiblockInfoRecipeWrapper> multiblockRecipes = new HashMap<String, MultiblockInfoRecipeWrapper>() {{
@@ -86,12 +81,5 @@ public class MultiblockInfoCategory implements IRecipeCategory<MultiblockInfoRec
     @Override
     public void setRecipe(IRecipeLayout recipeLayout, MultiblockInfoRecipeWrapper recipeWrapper, IIngredients ingredients) {
         recipeWrapper.setRecipeLayout((RecipeLayout) recipeLayout, this.guiHelper);
-    }
-
-    @Override
-    public void drawExtras(Minecraft minecraft) {
-        for (int i = 0; i < 20; ++i) {
-            this.slot.draw(minecraft, 18*i-180*(i/10), background.getHeight()-36+18*(i/10));
-        }
     }
 }

--- a/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
+++ b/src/main/java/gregtech/integration/jei/multiblock/MultiblockInfoRecipeWrapper.java
@@ -229,7 +229,6 @@ public class MultiblockInfoRecipeWrapper implements IRecipeWrapper, SceneRenderC
         // the button by mousing over it, leaks into other gui elements?
         for (GuiButton button : buttons.keySet()) {
             button.drawButton(minecraft, mouseX, mouseY, 0.0f);
-            minecraft.entityRenderer.enableLightmap();
         }
         guiHelper.drawableBuilder(new ResourceLocation(GTValues.MODID, "textures/gui/widget/information.png"), 0, 0, 20, 20)
                 .setTextureSize(20, 20)


### PR DESCRIPTION
**What:**
Fixed dimming on Multiblock page
Clean up of all opened files

**How solved:**
Removed `minecraft.entityRenderer.enableLightmap()` which caused to follow day night cycle.
Reordered way in which elements are added to page.
Overall clean up.